### PR TITLE
Add frame rate mode toggle

### DIFF
--- a/bothViewer.html
+++ b/bothViewer.html
@@ -179,7 +179,11 @@
             </h2>
             <div id="collapseFps" class="accordion-collapse collapse" aria-labelledby="headingFps" data-bs-parent="#settingsAccordion">
               <div class="accordion-body">
-                <div class="input-group">
+                <div class="d-grid gap-2">
+                  <button class="btn btn-secondary" onclick="setFramerateMode('Manual')">Manual</button>
+                  <button class="btn btn-secondary" onclick="setFramerateMode('Auto')">Auto</button>
+                </div>
+                <div class="input-group mt-2">
                   <input type="number" id="fps_manual_value" class="form-control" placeholder="FPS Value">
                   <button class="btn btn-secondary" onclick="setFramerate()">Set Frame Rate</button>
                 </div>
@@ -420,6 +424,20 @@
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ mode: 'Manual', value: manual_value })
+      })
+      .then(response => response.json())
+      .then(data => {
+        showToast("Frame: " + data.message);
+        updateExposureManualField();
+      })
+      .catch(err => console.error(err));
+    }
+
+    function setFramerateMode(mode) {
+      fetch('http://127.0.0.1:5002/set_framerate_mode', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ mode: mode })
       })
       .then(response => response.json())
       .then(data => {

--- a/frameStreamer.py
+++ b/frameStreamer.py
@@ -444,6 +444,25 @@ def set_framerate():
     except Exception as e:
         return jsonify({"status": "error", "message": str(e)}), 500
 
+# --- FrameRate モード切替用 API エンドポイント ---
+@app.route('/set_framerate_mode', methods=['POST'])
+def set_framerate_mode():
+    data = request.get_json()
+    mode = data.get('mode')
+    if mode not in ['Manual', 'Auto']:
+        return jsonify({"status": "error", "message": "Invalid mode specified. Use 'Manual' or 'Auto'."}), 400
+    try:
+        cam = frame_streamer_instance.cam_thread.cam
+        if cam is None:
+            return jsonify({"status": "error", "message": "カメラが初期化されていません。"}), 500
+
+        enable_manual = (mode == 'Manual')
+        cam.AcquisitionFrameRateEnable.set(enable_manual)
+        current_mode = 'Manual' if cam.AcquisitionFrameRateEnable.get() else 'Auto'
+        return jsonify({"status": "success", "message": f"Frame rate mode set to {current_mode}."})
+    except Exception as e:
+        return jsonify({"status": "error", "message": str(e)}), 500
+
 # --- WhiteBalance 設定用 API エンドポイント ---
 @app.route('/set_whitebalance', methods=['POST'])
 def set_whitebalance():


### PR DESCRIPTION
## Summary
- add API endpoint `/set_framerate_mode` to toggle manual/auto frame rate
- expose Manual/Auto buttons in Frame Rate settings UI
- implement `setFramerateMode` JavaScript helper

## Testing
- `python -m py_compile frameStreamer.py`

------
https://chatgpt.com/codex/tasks/task_e_6846a723155c8323b86433722055daa0