### PR TITLE
Make config file path module-relative

### DIFF
--- a/config_manager.py
+++ b/config_manager.py
@@ -4,11 +4,11 @@
 CopyPolicy: 
     Released under the terms of the LGPLv2.1 or later.
 """
-import yaml
 import os
+import yaml
 from datetime import datetime
 
-CONFIG_FILE = "config.yaml"
+CONFIG_FILE = os.path.join(os.path.dirname(__file__), "config.yaml")
 
 def load_config():
     if not os.path.exists(CONFIG_FILE):


### PR DESCRIPTION
## Summary
- ensure `config_manager.py` uses a module-relative config path

## Testing
- `python -m py_compile config_manager.py`
- `python -m pip install PyYAML` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_6846b2aba0e4832381037290c77ef290