### PR TITLE
Optimize EVS streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,14 @@ The event stream server starts on port `5001` and the frame stream server starts
 
 ## Performance
 
-`frameStreamer.py` encodes each captured frame to JPEG only once and streams the
-cached bytes to clients. This reduces repetitive conversions and lowers CPU
+Both streamers encode frames to JPEG only once and then share the cached
+bytes with connected clients. This avoids repeated conversions and lowers CPU
 usage, which is especially helpful on resource constrained devices such as the
 Raspberry Pi.
 
 You can further reduce CPU usage by lowering the display scale factor. Pass
-`--display-factor 0.3` (for example) when starting `frameStreamer.py` to
-downscale frames before encoding.
+`--display-factor 0.3` (for example) when starting `frameStreamer.py` or
+`evsStreamer.py` to downscale frames before encoding.
 
 ## License
 


### PR DESCRIPTION
## Summary
- reduce EVS conversion cost by scaling and pre-encoding frames in `evsStreamer.py`
- add `--display-factor` option for event stream server
- update docs about JPEG caching and scaling for both streamers

## Testing
- `python -m py_compile evsStreamer.py frameStreamer.py config_manager.py global_calc.py global_process.py launcher.py`

------
https://chatgpt.com/codex/tasks/task_e_6847c17d38988323bf534c481cb9445d