### PR TITLE
Allow setting pixel format

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,25 @@ bytes with connected clients. This avoids repeated conversions and lowers CPU
 usage, which is especially helpful on resource constrained devices such as the
 Raspberry Pi.
 
+
+### Pixel Format
+
+The frame camera's pixel format can be configured in `config.yaml` under
+`frameCam.pixel_format`. The default is `RGB8`, but `Mono8` or
+`YCbCr411_8_CbYYCrYY` can be selected for higher frame rates. You can also
+specify the format when starting `frameStreamer.py`:
+
+```bash
+python frameStreamer.py --pixel-format Mono8
+```
+
+During runtime the format may be changed via the `/set_pixel_format` API:
+
+```bash
+curl -X POST -H "Content-Type: application/json" \
+     -d '{"format":"YCbCr411_8_CbYYCrYY"}' http://localhost:5002/set_pixel_format
+```
+
 You can further reduce CPU usage by lowering the display scale factor. Pass
 `--display-factor 0.3` (for example) when starting `frameStreamer.py` or
 `evsStreamer.py` to downscale frames before encoding.

--- a/config.yaml
+++ b/config.yaml
@@ -9,6 +9,7 @@ frameCam:
   gain:
     mode: "Manual"
     value: 0
+  pixel_format: "RGB8"
 
 recording:
   save_location: "./recordings"

--- a/config_manager.py
+++ b/config_manager.py
@@ -19,7 +19,8 @@ def load_config():
             },
             "frameCam": {
                 "exposure": "Once",
-                "gain": {"mode": "Manual", "value": 0}
+                "gain": {"mode": "Manual", "value": 0},
+                "pixel_format": "RGB8"
             },
             "recording": {
                 "save_location": "./recordings",


### PR DESCRIPTION
## Summary
- add pixel_format option in `config.yaml` and default config
- expose pixel format controls in `frameStreamer`
- provide API endpoint `/set_pixel_format`
- document pixel format setting in README
- validate requested format against supported list

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6848f3b775e88323bd58f8e6025e78fe